### PR TITLE
Add single-bot Hermes channel routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ OLLAMA_BASE_URL=http://127.0.0.1:11436
 # Discord gateway
 DISCORD_BOT_TOKEN=
 DISCORD_ALLOWED_USERS=
+DISCORD_ALLOWED_CHANNELS=
 DISCORD_HOME_CHANNEL=
 
 # Local monitoring ports. These bind to 127.0.0.1 only.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PY := .venv/bin/python
 PIP := .venv/bin/pip
 
-.PHONY: setup dev-setup test config config-full up up-lite up-full down logs doctor backup tailscale-serve tailscale-serve-uptime
+.PHONY: setup dev-setup test config config-full check-channel-routing up up-lite up-full down logs doctor backup tailscale-serve tailscale-serve-uptime
 
 setup:
 	bash scripts/init-env.sh
@@ -20,6 +20,9 @@ config: setup
 
 config-full: setup
 	. ./.env; test -n "$${GRAFANA_ROOT_URL}" && test -n "$${GRAFANA_ADMIN_PASSWORD}" && docker compose --profile monitoring-lite --profile monitoring-full config >/dev/null
+
+check-channel-routing: dev-setup setup
+	$(PY) scripts/check-channel-routing.py
 
 up:
 	docker compose up -d hermes-gateway hermes-dashboard

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Docker-based Hermes Agent gateway, dashboard, and monitoring baseline for a work
 - Lightweight monitoring with Uptime Kuma, Dozzle, and a Caddy monitor proxy.
 - Optional full metrics with Prometheus, Grafana, node-exporter, and cAdvisor.
 - Tailscale Serve access through a single localhost proxy.
+- Single-bot channel routing for PMO, Development A PM, and Development B PM virtual agents.
 
 ## Quickstart
 
@@ -21,6 +22,7 @@ Edit `.env` before real use:
 
 - `DISCORD_BOT_TOKEN`
 - `DISCORD_ALLOWED_USERS`
+- `DISCORD_ALLOWED_CHANNELS`
 - `DISCORD_HOME_CHANNEL`
 - `OLLAMA_BASE_URL`
 - `HERMES_MODEL`
@@ -47,3 +49,5 @@ For the optional Grafana profile, set `GRAFANA_ROOT_URL` in `.env` to the exact 
 - Keep runtime state and secrets out of git.
 
 See [docs/runbook.md](docs/runbook.md) for operations, monitoring, Raspberry Pi / mini PC notes, and failure handling.
+
+See [docs/multi-role-agents.md](docs/multi-role-agents.md) for single-bot channel routing and virtual agent setup.

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,8 @@ services:
     stdin_open: true
     tty: true
     env_file:
-      - .env
+      - path: .env
+        required: false
     volumes:
       - ./data/hermes:/opt/data
       - ./.env:/opt/data/.env:ro
@@ -38,7 +39,8 @@ services:
     depends_on:
       - hermes-gateway
     env_file:
-      - .env
+      - path: .env
+        required: false
     volumes:
       - ./data/hermes:/opt/data
       - ./.env:/opt/data/.env:ro

--- a/config/hermes/config.yaml.example
+++ b/config/hermes/config.yaml.example
@@ -24,8 +24,28 @@ display:
 
 discord:
   require_mention: true
-  allowed_channels: ""
+  allowed_channels: "${DISCORD_ALLOWED_CHANNELS}"
   free_response_channels: ""
   auto_thread: true
   reactions: true
   server_actions: "list_guilds,list_channels,channel_info,fetch_messages,create_thread"
+  channel_prompts:
+    "REPLACE_WITH_PMO_CHANNEL_ID": |
+      You are the PMO virtual agent for this Discord channel.
+      Keep work Issue-backed, summarize cross-project status, track risks, and coordinate next actions.
+      Ask for human confirmation before high-risk scope changes. Prefer TDD and small PRs.
+    "REPLACE_WITH_DEV_A_CHANNEL_ID": |
+      You are the Development A PM virtual agent for this Discord channel.
+      Keep Development A work scoped, Issue-backed, TDD-oriented, and ready for review.
+      Track blockers, acceptance criteria, test evidence, and delivery risks.
+    "REPLACE_WITH_DEV_B_CHANNEL_ID": |
+      You are the Development B PM virtual agent for this Discord channel.
+      Keep Development B work scoped, Issue-backed, TDD-oriented, and ready for review.
+      Track blockers, acceptance criteria, test evidence, and delivery risks.
+  channel_skill_bindings:
+    - id: "REPLACE_WITH_PMO_CHANNEL_ID"
+      skills: ["plan", "github-issues"]
+    - id: "REPLACE_WITH_DEV_A_CHANNEL_ID"
+      skills: ["plan", "test-driven-development", "github-pr-workflow"]
+    - id: "REPLACE_WITH_DEV_B_CHANNEL_ID"
+      skills: ["plan", "test-driven-development", "github-pr-workflow"]

--- a/docs/multi-role-agents.md
+++ b/docs/multi-role-agents.md
@@ -1,0 +1,66 @@
+# Multi-Role Hermes Agents
+
+Use a single Discord bot and one Hermes gateway, then split work by Discord channel or forum thread. This avoids creating a new bot token for every future project while still keeping PMO and project conversations separated.
+
+## Recommended Shape
+
+- `#pmo` -> PMO virtual agent
+- `#dev-a` -> Development A PM virtual agent
+- `#dev-b` -> Development B PM virtual agent
+- Discord forum thread -> project-specific PM context under the parent forum route
+
+Hermes supports this through Discord `channel_prompts` and `channel_skill_bindings` in `data/hermes/config.yaml`. A channel prompt is injected only for that channel or forum parent, and skill bindings preload the right workflow skills for that context.
+
+## Setup
+
+Keep one bot token in `.env`:
+
+```bash
+DISCORD_BOT_TOKEN=
+DISCORD_ALLOWED_USERS=
+DISCORD_ALLOWED_CHANNELS=111111111111111111,222222222222222222,333333333333333333
+DISCORD_HOME_CHANNEL=111111111111111111
+```
+
+Copy the example config with `make setup`, then replace the placeholder keys in `data/hermes/config.yaml`:
+
+```yaml
+discord:
+  allowed_channels: "${DISCORD_ALLOWED_CHANNELS}"
+  channel_prompts:
+    "111111111111111111": |
+      You are the PMO virtual agent for this Discord channel.
+    "222222222222222222": |
+      You are the Development A PM virtual agent for this Discord channel.
+  channel_skill_bindings:
+    - id: "111111111111111111"
+      skills: ["plan", "github-issues"]
+    - id: "222222222222222222"
+      skills: ["plan", "test-driven-development", "github-pr-workflow"]
+```
+
+Validate the route setup before starting Discord work:
+
+```bash
+make check-channel-routing
+```
+
+## Operating Rules
+
+- Keep `DISCORD_ALLOWED_CHANNELS` as a whitelist, not `*`.
+- Prefer one Discord channel per durable role or project stream.
+- Use forum posts or threads for project subtopics so they inherit the parent channel prompt.
+- Keep high-risk actions issue-backed and reviewed; the virtual agent should coordinate, not bypass the Issue -> TDD -> PR flow.
+- Use Tailscale only for the monitoring dashboard; Discord remains the chat entrypoint.
+
+## Scaling
+
+Add a new development stream by adding one channel or forum parent ID to:
+
+- `.env` `DISCORD_ALLOWED_CHANNELS`
+- `data/hermes/config.yaml` `discord.channel_prompts`
+- `data/hermes/config.yaml` `discord.channel_skill_bindings`
+
+Do not add a new Discord bot unless you need a separate permission boundary, a separate Discord application identity, or independent gateway uptime. For unknown project counts, channel routing is the default.
+
+For Raspberry Pi or mini PC deployments, keep this single-gateway shape and point Hermes at Ollama running on a stronger host over LAN or Tailscale when local memory is tight.

--- a/scripts/check-channel-routing.py
+++ b/scripts/check-channel-routing.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import yaml
+
+
+ROOT = Path.cwd()
+ENV_PATH = ROOT / ".env"
+CONFIG_PATH = ROOT / "data" / "hermes" / "config.yaml"
+PLACEHOLDER_PREFIX = "REPLACE_WITH_"
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_env(path: Path) -> dict[str, str]:
+    if not path.exists():
+        fail("Missing .env; run make setup and fill Discord settings first.")
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        value = value.strip().strip('"').strip("'")
+        values[key.strip()] = value
+    return values
+
+
+def split_csv(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def main() -> None:
+    env = read_env(ENV_PATH)
+    for key in ("DISCORD_BOT_TOKEN", "DISCORD_ALLOWED_USERS", "DISCORD_ALLOWED_CHANNELS"):
+        if not env.get(key):
+            fail(f"{key} is required for single-bot channel routing.")
+
+    if not CONFIG_PATH.exists():
+        fail("Missing data/hermes/config.yaml; run make setup first.")
+
+    config = yaml.safe_load(CONFIG_PATH.read_text()) or {}
+    discord = config.get("discord") or {}
+    channel_prompts = discord.get("channel_prompts") or {}
+    channel_skill_bindings = discord.get("channel_skill_bindings") or []
+
+    if not isinstance(channel_prompts, dict) or not channel_prompts:
+        fail("discord.channel_prompts must define at least one channel route.")
+    if not isinstance(channel_skill_bindings, list) or not channel_skill_bindings:
+        fail("discord.channel_skill_bindings must define at least one channel route.")
+
+    prompt_ids = {str(channel_id) for channel_id in channel_prompts}
+    skill_ids = [str(entry.get("id", "")) for entry in channel_skill_bindings if isinstance(entry, dict)]
+    route_ids = prompt_ids | set(skill_ids)
+    if any(channel_id.startswith(PLACEHOLDER_PREFIX) for channel_id in route_ids):
+        fail("replace channel route placeholders in data/hermes/config.yaml before starting.")
+    if len(skill_ids) != len(set(skill_ids)):
+        fail("discord.channel_skill_bindings contains duplicate channel ids.")
+
+    allowed_channels = set(split_csv(env["DISCORD_ALLOWED_CHANNELS"]))
+    if "*" in allowed_channels:
+        fail("DISCORD_ALLOWED_CHANNELS must list explicit channel ids for channel routing.")
+
+    missing_prompt_routes = sorted(allowed_channels - prompt_ids)
+    missing_skill_routes = sorted(allowed_channels - set(skill_ids))
+    if missing_prompt_routes:
+        fail(f"missing channel_prompts for allowed channels: {', '.join(missing_prompt_routes)}")
+    if missing_skill_routes:
+        fail(f"missing channel_skill_bindings for allowed channels: {', '.join(missing_skill_routes)}")
+
+    print("channel routing config looks valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_baseline_files.py
+++ b/tests/test_baseline_files.py
@@ -20,7 +20,7 @@ def test_compose_defines_hermes_monitoring_and_profiles():
         "CMD-SHELL",
         "/opt/hermes/.venv/bin/hermes status >/tmp/hermes-status.out 2>&1",
     ]
-    assert services["hermes-gateway"]["env_file"] == [".env"]
+    assert services["hermes-gateway"]["env_file"] == [{"path": ".env", "required": False}]
     assert "./.env:/opt/data/.env:ro" in services["hermes-gateway"]["volumes"]
     assert "./:/workspace:ro" in services["hermes-gateway"]["volumes"]
     assert services["hermes-dashboard"]["command"] == [
@@ -68,6 +68,7 @@ def test_env_example_documents_discord_ollama_and_tailscale_defaults():
     for key in [
         "DISCORD_BOT_TOKEN=",
         "DISCORD_ALLOWED_USERS=",
+        "DISCORD_ALLOWED_CHANNELS=",
         "DISCORD_HOME_CHANNEL=",
         "OLLAMA_BASE_URL=http://127.0.0.1:11436",
         "HERMES_MODEL=gemma4:e4b",
@@ -148,6 +149,8 @@ def test_lite_compose_config_works_with_env_example():
             "compose",
             "--env-file",
             ".env.example",
+            "-f",
+            "compose.yaml",
             "--profile",
             "monitoring-lite",
             "config",
@@ -169,6 +172,8 @@ def test_config_full_preflight_requires_grafana_root_url():
             "compose",
             "--env-file",
             ".env.example",
+            "-f",
+            "compose.yaml",
             "--profile",
             "monitoring-lite",
             "--profile",

--- a/tests/test_multi_role_agents.py
+++ b/tests/test_multi_role_agents.py
@@ -1,0 +1,185 @@
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTE_PLACEHOLDERS = {
+    "REPLACE_WITH_PMO_CHANNEL_ID": "PMO",
+    "REPLACE_WITH_DEV_A_CHANNEL_ID": "Development A PM",
+    "REPLACE_WITH_DEV_B_CHANNEL_ID": "Development B PM",
+}
+
+
+def test_single_gateway_uses_one_discord_bot_with_channel_routes():
+    compose = yaml.safe_load((ROOT / "compose.yaml").read_text())
+    services = compose["services"]
+
+    assert "hermes-gateway" in services
+    assert "hermes-pmo-gateway" not in services
+    assert "hermes-dev-a-pm-gateway" not in services
+    assert "hermes-dev-b-pm-gateway" not in services
+    assert services["hermes-gateway"]["container_name"] == "hermes-gateway"
+    assert services["hermes-gateway"]["command"] == ["gateway", "run"]
+
+
+def test_config_example_defines_channel_prompts_and_skill_bindings():
+    config = yaml.safe_load((ROOT / "config" / "hermes" / "config.yaml.example").read_text())
+    discord = config["discord"]
+
+    assert discord["allowed_channels"] == "${DISCORD_ALLOWED_CHANNELS}"
+    assert set(discord["channel_prompts"]) == set(ROUTE_PLACEHOLDERS)
+
+    for channel_id, role_label in ROUTE_PLACEHOLDERS.items():
+        prompt = discord["channel_prompts"][channel_id]
+        assert role_label in prompt
+        assert "Issue" in prompt
+        assert "TDD" in prompt
+
+    bindings = {entry["id"]: entry["skills"] for entry in discord["channel_skill_bindings"]}
+    assert set(bindings) == set(ROUTE_PLACEHOLDERS)
+    assert "github-issues" in bindings["REPLACE_WITH_PMO_CHANNEL_ID"]
+    assert "github-pr-workflow" in bindings["REPLACE_WITH_DEV_A_CHANNEL_ID"]
+    assert "test-driven-development" in bindings["REPLACE_WITH_DEV_B_CHANNEL_ID"]
+
+
+def test_env_example_documents_single_bot_channel_allowlist():
+    env_example = (ROOT / ".env.example").read_text()
+
+    assert "DISCORD_BOT_TOKEN=" in env_example
+    assert "DISCORD_ALLOWED_USERS=" in env_example
+    assert "DISCORD_ALLOWED_CHANNELS=" in env_example
+    assert "DISCORD_HOME_CHANNEL=" in env_example
+
+
+def test_channel_routing_preflight_rejects_placeholders(tmp_path):
+    shutil.copy2(ROOT / "scripts" / "check-channel-routing.py", tmp_path / "check-channel-routing.py")
+
+    env = tmp_path / ".env"
+    env.write_text(
+        "\n".join(
+            [
+                "DISCORD_BOT_TOKEN=test-token",
+                "DISCORD_ALLOWED_USERS=123",
+                "DISCORD_ALLOWED_CHANNELS=111,222,333",
+                "",
+            ]
+        )
+    )
+    config_dir = tmp_path / "data" / "hermes"
+    config_dir.mkdir(parents=True)
+    shutil.copy2(ROOT / "config" / "hermes" / "config.yaml.example", config_dir / "config.yaml")
+
+    result = subprocess.run(
+        [sys.executable, "check-channel-routing.py"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "replace channel route placeholders" in result.stderr
+
+
+def test_channel_routing_preflight_rejects_wildcard_allowed_channels(tmp_path):
+    shutil.copy2(ROOT / "scripts" / "check-channel-routing.py", tmp_path / "check-channel-routing.py")
+
+    env = tmp_path / ".env"
+    env.write_text(
+        "\n".join(
+            [
+                "DISCORD_BOT_TOKEN=test-token",
+                "DISCORD_ALLOWED_USERS=123",
+                "DISCORD_ALLOWED_CHANNELS=*",
+                "",
+            ]
+        )
+    )
+    config_dir = tmp_path / "data" / "hermes"
+    config_dir.mkdir(parents=True)
+    config = yaml.safe_load((ROOT / "config" / "hermes" / "config.yaml.example").read_text())
+    config["discord"]["channel_prompts"] = {"111": "PMO route prompt"}
+    config["discord"]["channel_skill_bindings"] = [{"id": "111", "skills": ["plan"]}]
+    (config_dir / "config.yaml").write_text(yaml.safe_dump(config, sort_keys=False))
+
+    result = subprocess.run(
+        [sys.executable, "check-channel-routing.py"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "DISCORD_ALLOWED_CHANNELS must list explicit channel ids" in result.stderr
+
+
+def test_channel_routing_preflight_accepts_single_bot_routes(tmp_path):
+    shutil.copy2(ROOT / "scripts" / "check-channel-routing.py", tmp_path / "check-channel-routing.py")
+
+    env = tmp_path / ".env"
+    env.write_text(
+        "\n".join(
+            [
+                "DISCORD_BOT_TOKEN=test-token",
+                "DISCORD_ALLOWED_USERS=123",
+                "DISCORD_ALLOWED_CHANNELS=111,222,333",
+                "",
+            ]
+        )
+    )
+    config_dir = tmp_path / "data" / "hermes"
+    config_dir.mkdir(parents=True)
+    config = yaml.safe_load((ROOT / "config" / "hermes" / "config.yaml.example").read_text())
+    discord = config["discord"]
+    discord["channel_prompts"] = {
+        "111": "PMO route prompt",
+        "222": "Development A PM route prompt",
+        "333": "Development B PM route prompt",
+    }
+    discord["channel_skill_bindings"] = [
+        {"id": "111", "skills": ["plan", "github-issues"]},
+        {"id": "222", "skills": ["plan", "github-pr-workflow"]},
+        {"id": "333", "skills": ["test-driven-development", "github-pr-workflow"]},
+    ]
+    (config_dir / "config.yaml").write_text(yaml.safe_dump(config, sort_keys=False))
+
+    result = subprocess.run(
+        [sys.executable, "check-channel-routing.py"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "channel routing config looks valid" in result.stdout
+
+
+def test_multi_role_docs_describe_single_bot_virtual_agents():
+    doc = (ROOT / "docs" / "multi-role-agents.md").read_text().lower()
+
+    for phrase in [
+        "single discord bot",
+        "channel_prompts",
+        "channel_skill_bindings",
+        "virtual agent",
+        "pmo",
+        "development a pm",
+        "development b pm",
+        "forum thread",
+        "bot token",
+        "tailscale",
+    ]:
+        assert phrase in doc
+
+
+def test_makefile_exposes_channel_route_validation():
+    makefile = (ROOT / "Makefile").read_text()
+
+    assert "check-channel-routing:" in makefile
+    assert "scripts/check-channel-routing.py" in makefile


### PR DESCRIPTION
## Summary
- Switch Issue #4 from bot-per-role scaling to one Discord bot with channel-based virtual agents.
- Add Hermes Discord `channel_prompts` and `channel_skill_bindings` examples for PMO, Development A PM, and Development B PM.
- Add `make check-channel-routing` to validate runtime `.env` and `data/hermes/config.yaml` before Discord operations.
- Document why channel/forum routing is the default for unknown project counts.

## Tests
- `make test` -> 20 passed
- `make config` -> passed; Docker still warns that `~/.docker/config.json` is malformed
- `.venv/bin/python scripts/check-channel-routing.py` -> expected safe failure because runtime Discord secrets/channels are not filled locally

## Rollback
- Revert this PR to remove channel route examples and the validation command. Existing single-gateway Compose behavior remains the baseline.

Closes #4